### PR TITLE
Update ContainSplicePortsInSpliceEnclosure.js

### DIFF
--- a/attribute_rule_calculation/Telecom/ContainSplicePortsInSpliceEnclosure.js
+++ b/attribute_rule_calculation/Telecom/ContainSplicePortsInSpliceEnclosure.js
@@ -1,7 +1,7 @@
 // Assigned To: CommunicationsDevice
 // Name: Contain Splice Ports in Splice Enclosure
 // Description: Contain Splice Ports in Splice Enclosure using the ContainerGuid field
-// Subtypes: Port
+// Subtypes: Splice
 // Field: AssetID
 // Execute: Insert
 // ***************************************


### PR DESCRIPTION
Changed documentation in code to assign to "Splice" instead of "Port" as the model has now moved Splice to a separate asset group