### PR TITLE
Ted telecom duct rule

### DIFF
--- a/Industry/Telecom/SL-CreateDuctInBank.js
+++ b/Industry/Telecom/SL-CreateDuctInBank.js
@@ -164,15 +164,15 @@ for (var j = 0; j < duct_count; j++) {
     if (assign_port_numbers) {
         fromport_value = next_avail(from_knockout_used_ports);
         from_knockout_used_ports[Count(from_knockout_used_ports)] = fromport_value;
-        toport_value = next_avail(to_knockout_used_ports, to_duct_count);
+        toport_value = next_avail(to_knockout_used_ports);
         to_knockout_used_ports[Count(to_knockout_used_ports)] = toport_value
     }
     line_attributes = {
         'AssetGroup': duct_AG,
         'AssetType': duct_AT,
-        duct_from_port_num: fromport_value,
-        duct_to_port_num: toport_value
     };
+    line_attributes[duct_from_port_num] = fromport_value;
+    line_attributes[duct_to_port_num] = toport_value;
     line_adds[Count(line_adds)] = {
         'attributes': line_attributes,
         'geometry': Polyline(content_shape),

--- a/Industry/Telecom/SL-CreateDuctInBank.js
+++ b/Industry/Telecom/SL-CreateDuctInBank.js
@@ -105,6 +105,30 @@ function next_avail(arr) {
     }
 }
 
+// get lookup for from -> to port numbers
+// example height = 2, width = 3  ->  {"1": 3, "2": 2, "3": 1, "4": 6, "5": 5, "6": 4}
+function get_port_lookup(height, width) {
+    var array = [];
+    var counter = 1;
+    var lookup_dict = {};
+    for (var j = 0; j < height; j++) {
+        var new_row = [];
+        for (var k = 0; k < width; k++) {
+            new_row[k] = counter;
+            counter++;
+        }
+        array[j] = new_row;
+    }
+
+    for (var idx in array) {
+        var rev_row = Reverse(array[idx]);
+        for (var i in array[idx]) {
+            lookup_dict[Text(array[idx][i])] = rev_row[i];
+        }
+    }
+    return lookup_dict;
+}
+
 
 // ************* Validation *****************
 // Limit the rule to valid subtypes
@@ -129,7 +153,9 @@ if (IsEmpty(from_snapped_feat)) {
 }
 // Get count of available duct ports in a knockout. Check using height and width of knockout from attribute fields.
 // Account for ducts that may already be snapped to knockout.
-var from_duct_count = DefaultValue(from_snapped_feat[knock_out_duct_wide_field], 0) * DefaultValue(from_snapped_feat[knock_out_duct_high_field], 0);
+var height_from = DefaultValue(from_snapped_feat[knock_out_duct_high_field], 0);
+var width_from = DefaultValue(from_snapped_feat[knock_out_duct_wide_field], 0);
+var from_duct_count = width_from * height_from;
 var from_duct_occupied = Count(get_snapped_lines(from_point, false));
 if (from_duct_count - from_duct_occupied < duct_count) {
     return {'errorMessage': 'A duct bank has more ducts than the knock out at the start of the line can support.'};
@@ -138,7 +164,9 @@ var to_snapped_feat = get_snapped_point(to_point);
 if (IsEmpty(to_snapped_feat)) {
     return {'errorMessage': 'A duct bank must end at a knock out'};
 }
-var to_duct_count = DefaultValue(to_snapped_feat[knock_out_duct_wide_field], 0) * DefaultValue(to_snapped_feat[knock_out_duct_high_field], 0);
+var height_to = DefaultValue(to_snapped_feat[knock_out_duct_high_field], 0);
+var width_to = DefaultValue(to_snapped_feat[knock_out_duct_wide_field], 0);
+var to_duct_count = width_to * height_to;
 var to_duct_occupied = Count(get_snapped_lines(to_point, false));
 if (to_duct_count - to_duct_occupied < duct_count) {
     return {'errorMessage': 'A duct bank has more ducts than the knock out at the end of the line can support.'};
@@ -146,6 +174,14 @@ if (to_duct_count - to_duct_occupied < duct_count) {
 
 
 // ************* Create Payload *****************
+// special logic if both knockouts are empty and same dimensions H x W
+var port_lookup = null;
+if (from_duct_occupied + to_duct_occupied < 1) {
+    if (height_from == height_to && width_from == width_to){
+        port_lookup = get_port_lookup(height_from, width_from);
+    }
+}
+
 // handle port numbers. used_ports variables are arrays containing integers
 var from_knockout_used_ports = get_used_ports(from_point);
 var to_knockout_used_ports = get_used_ports(to_point);
@@ -164,8 +200,11 @@ for (var j = 0; j < duct_count; j++) {
     if (assign_port_numbers) {
         fromport_value = next_avail(from_knockout_used_ports);
         from_knockout_used_ports[Count(from_knockout_used_ports)] = fromport_value;
-        toport_value = next_avail(to_knockout_used_ports);
-        to_knockout_used_ports[Count(to_knockout_used_ports)] = toport_value
+        if (port_lookup != null) {
+            toport_value = port_lookup[Text(fromport_value)];
+        } else {toport_value = next_avail(to_knockout_used_ports);
+        to_knockout_used_ports[Count(to_knockout_used_ports)] = toport_value;
+        }
     }
     line_attributes = {
         'AssetGroup': duct_AG,

--- a/Industry/Telecom/SL-CreateDuctInBank.js
+++ b/Industry/Telecom/SL-CreateDuctInBank.js
@@ -16,14 +16,13 @@ var duct_count = $feature.maximumcapacity;
 // The Asset Group and Asset Type of the duct
 var duct_AG = 101;
 var duct_AT = 41;
+var duct_from_portid = 'fromportid';
+var duct_to_portid = 'toportid';
 var knock_out_sql = "AssetGroup = 110 and AssetType = 363";
 var knock_out_duct_wide_field = 'ductcountwide';
 var knock_out_duct_high_field = 'ductcounthigh';
-var point_spacing = .5;
-var offset_distance = .1;
 var z_level = -10000;
-var new_knock_out_port_feature_AG = 110;
-var new_knock_out_port_feature_AT = 364;
+
 
 function get_features_switch_yard(class_name, fields, include_geometry) {
     var class_name = Split(class_name, '.')[-1];
@@ -39,20 +38,8 @@ function get_features_switch_yard(class_name, fields, include_geometry) {
 }
 
 // ************* End Section *****************
-function pop_empty(dict) {
-    var new_dict = {};
-    for (var k in dict) {
-        if (IsNan(dict[k])) {
-            continue;
-        }
-        if (IsEmpty(dict[k])) {
-            continue;
-        }
-        new_dict[k] = dict[k];
-    }
-    return new_dict
-}
 
+// update all z-values and drop m-values
 function adjust_z(line_dict, z_value) {
     var new_paths = [];
     for (var i in line_dict['paths']) {
@@ -61,26 +48,15 @@ function adjust_z(line_dict, z_value) {
         for (var j in current_path) {
             new_path[Count(new_path)] = [current_path[j][0], current_path[j][1], z_value];
         }
-        new_paths[count(new_paths)] = new_path
+        new_paths[Count(new_paths)] = new_path
     }
     line_dict['paths'] = new_paths;
     return line_dict
 }
 
-function point_to_array(point_geo) {
-    if (IsEmpty(point_geo)) {
-        return null
-    }
-    if (typeof (point_geo) == 'Array') {
-        return point_geo;
-    }
-    if (HasKey(Dictionary(Text(point_geo)), 'x') == false) {
-        return null
-    }
-    return [point_geo.x, point_geo.y, point_geo.z, 0]
-}
-
+// get "StructureJunction" feature that intersect with input point geo json. filter using knock_out_sql. returns Point type or null
 function get_snapped_point(point_geo) {
+    // TODO: make sure switching to point_class didn't break anything
     var fs = get_features_switch_yard("StructureJunction", ["globalid", "assetgroup", 'assettype', knock_out_duct_high_field, knock_out_duct_wide_field], false);
     var snapped_feats = Intersects(fs, Point(point_geo));
     var snapped_feat = First(Filter(snapped_feats, knock_out_sql));
@@ -88,55 +64,24 @@ function get_snapped_point(point_geo) {
         return snapped_feat;
     }
     return null;
-}
 
-function is_even(value) {
-    return (Number(value) % 2) == 0;
-}
-
-function angle_line_at_point(line_geo, point_on_line) {
-    var search = Extent(Buffer(point_on_line, .01, "meter"));
-    var segment = Clip(line_geo, search)["paths"][0];
-
-    // Get angle of line using the start and end vertex
-    return Angle(segment[0], segment[-1])
-}
-
-function offset_line(point_geo, point_count, point_spacing, offset_distance, line_rotation) {
-
-    var _point_count = point_count;
-    if (point_count == 1) {
-        _point_count = 3
-
+function next_avail(arr, num_ports) {
+    if (Count(arr) >= num_ports) {
+        return null;
     }
-
-    // Store the geometry of the point.  Offset the y and Z to get a vertical line that represents the upper coordinate
-    var point_y = point_geo.Y;
-    point_y = point_y - (floor(_point_count / 2) * point_spacing) + iif(is_even(point_count), point_spacing / 2, point_spacing / 4);
-    var point_z = point_geo.Z;
-    point_z = point_z - (floor(_point_count / 2) * point_spacing)  + iif(is_even(point_count), point_spacing / 2, point_spacing / 4);
-    var point_x = point_geo.X;
-
-    // Loop over the point count and add a vertex using the spacing
-    var vertices = [];
-    for (var i = 0; i < _point_count; i++) {
-        vertices[i] = [point_x, point_y, point_z];
-        point_y = point_y + point_spacing;
-        point_z = point_z + point_spacing;
+    var sorted_arr = sort(arr);
+    for (var i in sorted_arr) {
+        if (i+1 == sorted_arr[i]) {
+            continue;
+        }
+        arr[Count(arr)] = i+1;
+        return i+1
     }
-    // Create a new line, rotate it based on user field and offset to spread it from the placed point
-    var new_line = Polyline({"paths": [vertices], "spatialReference": {"wkid": point_geo.spatialReference.wkid}});
-    new_line = rotate(new_line, 90 - line_rotation);
-    if (offset_distance != 0) {
-        new_line = offset(new_line, offset_distance);
-    }
-    // Get the first path on the new line
-    return new_line['paths'][0];
 }
 
 // Validation
 // Limit the rule to valid subtypes
-if (indexof(valid_asset_types, $feature.assettype) == -1) {
+if (IndexOf(valid_asset_types, $feature.assettype) == -1) {
     return assigned_to_value;
 }
 // Require a value for duct count
@@ -151,15 +96,16 @@ var from_point = vertices[0];
 var to_point = vertices[-1];
 
 // Get the snapped feature.
-var from_snapped_feat = get_snapped_point(Point(from_point));
+var from_snapped_feat = get_snapped_point(from_point);
 if (IsEmpty(from_snapped_feat)) {
     return {'errorMessage': 'A duct bank must start at a knock out'};
 }
+// Get from duct count from from knockout attribute fields
 var from_duct_count = DefaultValue(from_snapped_feat[knock_out_duct_wide_field], 0) * DefaultValue(from_snapped_feat[knock_out_duct_high_field], 0);
 if (from_duct_count < duct_count) {
     return {'errorMessage': 'A duct bank has more ducts than the knock out at the start of the line can support'};
 }
-var to_snapped_feat = get_snapped_point(Point(to_point));
+var to_snapped_feat = get_snapped_point(to_point);
 if (IsEmpty(to_snapped_feat)) {
     return {'errorMessage': 'A duct bank must end at a knock out'};
 }
@@ -168,25 +114,7 @@ if (to_duct_count < duct_count) {
     return {'errorMessage': 'A duct bank has more ducts than the knock out at the end of the line can support'};
 }
 
-// Generate offset lines to move strands to when no port is found
-var start_angle = angle_line_at_point(assigned_line_geo, from_point);
-start_angle = (450 - start_angle) % 360;
-//start_angle = start_angle + 90;
-var end_angle = angle_line_at_point(assigned_line_geo, to_point);
-end_angle = (450 - end_angle) % 360;
-//end_angle = end_angle + 90;
-
-var contained_line_from_point = Dictionary(Text(from_point));
-contained_line_from_point['z'] = z_level;
-contained_line_from_point = pop_empty(contained_line_from_point);
-var contained_line_to_point = Dictionary(Text(to_point));
-contained_line_to_point['z'] = z_level;
-contained_line_to_point = pop_empty(contained_line_to_point);
-
-var from_offset_line = offset_line(Point(contained_line_from_point), duct_count, point_spacing, offset_distance, start_angle);
-var to_offset_line = offset_line(Point(contained_line_to_point), duct_count, point_spacing, offset_distance, end_angle);
-
-
+// Create payload to add new lines
 var line_attributes = {};
 var line_adds = [];
 var junction_adds = [];
@@ -197,14 +125,9 @@ var line_json = Text(assigned_line_geo);
 for (var j = 0; j < duct_count; j++) {
     var content_shape = Dictionary(line_json);
     content_shape = adjust_z(content_shape, z_level);
-    var new_from_point = point_to_array(from_offset_line[j]);
-    content_shape['paths'][0][0] = new_from_point;
-    var new_to_point = point_to_array(to_offset_line[j]);
-    content_shape['paths'][0][-1] = new_to_point;
     line_attributes = {
         'AssetGroup': duct_AG,
         'AssetType': duct_AT,
-        'ductid': j + 1
 
     };
     line_adds[Count(line_adds)] = {
@@ -212,29 +135,8 @@ for (var j = 0; j < duct_count; j++) {
         'geometry': Polyline(content_shape),
         'associationType': 'content'
     };
-    var from_junction_attributes = {
-        'AssetGroup': new_knock_out_port_feature_AG,
-        'AssetType': new_knock_out_port_feature_AT,
-        'assetid': j + 1,
-        'containerGUID': from_snapped_feat.globalid
-    };
-    var to_junction_attributes = {
-        'AssetGroup': new_knock_out_port_feature_AG,
-        'AssetType': new_knock_out_port_feature_AT,
-        'assetid': j + 1,
-        'containerGUID': to_snapped_feat.globalid
-    };
-    junction_adds[Count(junction_adds)] = {
-        'attributes': from_junction_attributes,
-        'geometry': from_offset_line[j]
-    };
-    junction_adds[Count(junction_adds)] = {
-        'attributes': to_junction_attributes,
-        'geometry': to_offset_line[j]
-    };
 }
-var edit_payload = [{'className': line_class, 'adds': line_adds},
-    {'className': point_class, 'adds': junction_adds}];
+var edit_payload = [{'className': line_class, 'adds': line_adds}];
 
 return {
     "result": assigned_to_value,

--- a/Industry/Telecom/SL-CreateDuctInBank.js
+++ b/Industry/Telecom/SL-CreateDuctInBank.js
@@ -18,11 +18,10 @@ var duct_AG = 101;
 var duct_AT = 41;
 var duct_from_portid = 'fromportid';
 var duct_to_portid = 'toportid';
-var knock_out_sql = "AssetGroup = 110 and AssetType = 363";
 var wire_duct_sql = "ASSETGROUP = 101 and ASSETTYPE = 41";
+var knock_out_sql = "AssetGroup = 110 and AssetType = 363";
 var knock_out_duct_wide_field = 'ductcountwide';
 var knock_out_duct_high_field = 'ductcounthigh';
-var z_level = -10000;
 
 
 function get_features_switch_yard(class_name, fields, include_geometry) {
@@ -39,11 +38,10 @@ function get_features_switch_yard(class_name, fields, include_geometry) {
     }
     return feature_set;
 }
-
 // ************* End Section *****************
 
 
-// get "StructureJunction" feature that intersect with input point geo json. filter using knock_out_sql. returns Point type or null
+// get "StructureJunction" feature that intersects with input point geometry. filter using knock_out_sql. returns Point type or null
 function get_snapped_point(point_geo) {
     var fs = get_features_switch_yard(point_class, ["globalid", "assetgroup", "assettype", knock_out_duct_high_field, knock_out_duct_wide_field], false);
     var snapped_feats = Intersects(fs, Point(point_geo));
@@ -54,7 +52,7 @@ function get_snapped_point(point_geo) {
     return null;
 }
 
-// get all wire ducts connected to knockout
+// get all wire ducts snapped to knockout. returns FeatureSet or null
 function get_snapped_lines(point_geo){
     var fs = get_features_switch_yard(line_class, [duct_from_portid, duct_to_portid], true)
     var snapped_feats = Intersects(fs, point_geo);
@@ -64,7 +62,7 @@ function get_snapped_lines(point_geo){
     return Filter(snapped_feats, wire_duct_sql)
 }
 
-// get used ports at knockout by checking all snapped wire ducts.
+// get used ports at knockout by checking all snapped wire ducts. returns Array
 function get_used_ports(point_geo){
     var used_ports = [];
     var existing_snapped_ducts = get_snapped_lines(point_geo);
@@ -87,7 +85,7 @@ function get_used_ports(point_geo){
     return used_ports;
 }
 
-// Find the lowest number not in array
+// Find the lowest number not in array. Returns Number or null
 function next_avail(arr, num_ports) {
     if (Count(arr) == 0) {
         return 1;
@@ -150,7 +148,7 @@ var to_knockout_used_ports = get_used_ports(to_point);
 var line_attributes = {};
 var line_adds = [];
 
-// Copy the line and move the Z
+// Copy the line as text
 var line_json = Text(assigned_line_geo);
 
 for (var j = 0; j < duct_count; j++) {


### PR DESCRIPTION
- Removed pop_empty
  - used to remove empty key values bc Point function will fail if found in a dictionary
  - not needed because contained_line_from_point and contained_line_to_point were removed
- Removed point_to_array
  - from and to points of wire ducts no longer need to be offset

- Removed is_even - used for offset
- Removed angle_line_at_point - used for offset
- Removed offset_line - used for offset
- Removed knockout ports from edit_payload. Don't think we need these anymore with no offset.
- Removed adjust_z function
  - No longer need bc all ducts are snapping directly to knock out

- Added sql clause for wire duct
- Added StructureLine as option in get_features_switch_yard
- Added get_snapped_lines
  - For finding all existing ducts snapped to a knockout
- Added get_used_ports
  - Find any ports that are already used by existing ducts snapped to a knockout
- Added next_avail
  - will find smallest integer not already in array
  - will be used to assign ids to wire ducts

- Updated payload builder
  - populate the fromportid and toportid fields for each new duct being created